### PR TITLE
models: fix get_parameters() for empty inputs

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -131,7 +131,7 @@ class Workflow(Base, Timestamp):
 
     def get_parameters(self):
         """Return workflow parameters."""
-        return self.reana_specification['inputs'].get('parameters', {})
+        return self.reana_specification.get('inputs', {}).get('parameters', {})
 
     def get_specification(self):
         """Return workflow specification."""

--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.4.0.dev20181018"
+__version__ = "0.4.0.dev201810181"


### PR DESCRIPTION
* Fixes Workflow.get_parameters() for the case of workflows without
  inputs.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>