### PR TITLE
models: store REANA Job status

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -65,6 +65,17 @@ class WorkflowStatus(enum.Enum):
     queued = 6
 
 
+class JobStatus(enum.Enum):
+    """Enumeration of possible job statuses."""
+
+    created = 0
+    running = 1
+    finished = 2
+    failed = 3
+    stopped = 4
+    queued = 5
+
+
 class Workflow(Base, Timestamp):
     """Workflow table."""
 
@@ -196,11 +207,10 @@ class Job(Base, Timestamp):
                  default=generate_uuid)
     workflow_uuid = Column(UUIDType)
     status = Column(String(30))
-    job_type = Column(String(30))
+    backend = Column(String(30))
     cvmfs_mounts = Column(Text)
     shared_file_system = Column(Boolean)
     docker_img = Column(String(256))
-    experiment = Column(String(256))
     cmd = Column(Text)
     env_vars = Column(Text)
     restart_count = Column(Integer)

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -205,8 +205,9 @@ class Job(Base, Timestamp):
 
     id_ = Column(UUIDType, unique=True, primary_key=True,
                  default=generate_uuid)
+    backend_job_id = Column(String(256))
     workflow_uuid = Column(UUIDType)
-    status = Column(String(30))
+    status = Column(Enum(JobStatus), default=JobStatus.created)
     backend = Column(String(30))
     cvmfs_mounts = Column(Text)
     shared_file_system = Column(Boolean)


### PR DESCRIPTION
* Since every computing bakcend has different names for errors,
  we need an internal way of identifying them. It will be task of
  each implementation to define the mapping between the specific
  computing backend and REANA.

* Renames `job_type` to `backend` to hold the backend type string.
  Connects reanahub/reana-job-controller/issues/118

Co-authored-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>