### PR TITLE
models: removes restart counts

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -220,8 +220,6 @@ class Job(Base, Timestamp):
     docker_img = Column(String(256))
     cmd = Column(JSONType)
     env_vars = Column(JSONType)
-    restart_count = Column(Integer)
-    max_restart_count = Column(Integer)
     deleted = Column(Boolean)
     logs = Column(String, nullable=True)
     prettified_cmd = Column(JSONType)


### PR DESCRIPTION
* Since internal K8S jobs restarts are disabled, these fields
  are not needed anymore.
  Addresses reanahub/reana-workflow-controller/issues/236

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>