### PR TITLE
setup: pin SQLAlchemy-Utils to 0.36.3 for python 2

### DIFF
--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200608"
+__version__ = "0.7.0.dev20200609"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup_requires = [
 install_requires = [
     "psycopg2-binary>=2.6.1",
     "SQLAlchemy>=1.2.7",
-    "sqlalchemy-utils>=0.31.0",
+    'sqlalchemy-utils>=0.36.3 ; python_version>="3"',
+    'sqlalchemy-utils==0.36.3 ; python_version=="2.7"',
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType
 ]
 


### PR DESCRIPTION
SQLAlchemy-Utils stopped supporting python 2.7 in version 0.36.4
https://github.com/kvesteri/sqlalchemy-utils/releases/tag/0.36.4