### PR TITLE
 setup: decrease sqlalchemy-utils min version 

### DIFF
--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200609"
+__version__ = "0.7.0.dev20200610"

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup_requires = [
 install_requires = [
     "psycopg2-binary>=2.6.1",
     "SQLAlchemy>=1.2.7",
-    'sqlalchemy-utils>=0.36.3 ; python_version>="3"',
-    'sqlalchemy-utils==0.36.3 ; python_version=="2.7"',
+    'sqlalchemy-utils>=0.35.0 ; python_version>="3"',
+    'sqlalchemy-utils<=0.36.3 ; python_version=="2.7"',
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType
 ]
 


### PR DESCRIPTION
Due to `invenio-db` pinning to `SQLAlchemy-Utils<0.36,>=0.33.1` and
r`eana-server` pinning to `SQLAlchemy-Utils[encrypted]>=0.33.0,<0.36.0 `to
satisfy invenio's requirements.