### PR TITLE
config: uses central FQDN component name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Version master (UNRELEASED)
 - Adds new column ``workspace_path`` to the Workflow table.
 - Adds fixtures for better testing models.
 - Amends database host configuration to respect REANA component prefixing.
+- Uses centrally configured database service name from REANA-Commons.
+- Adds REANA-Commons as a dependency.
 - Add Black formatter support.
 
 Version 0.6.0 (2019-12-19)

--- a/reana_db/config.py
+++ b/reana_db/config.py
@@ -10,6 +10,8 @@
 
 import os
 
+from reana_commons.config import REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES
+
 DB_NAME = os.getenv("REANA_DB_NAME", "reana")
 """Database name."""
 
@@ -19,9 +21,7 @@ DB_USERNAME = os.getenv("REANA_DB_USERNAME", "reana")
 DB_PASSWORD = os.getenv("REANA_DB_PASSWORD", "reana")
 """Database password."""
 
-DB_HOST = os.getenv(
-    "REANA_DB_HOST", "{}-db".format(os.getenv("REANA_COMPONENT_PREFIX"))
-)
+DB_HOST = REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES["db"]
 """Database service host."""
 # Loading REANA_COMPONENT_PREFIX from environment because REANA-DB
 # doesn't depend on REANA-Commons, the package which loads this config.

--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200610"
+__version__ = "0.7.0.dev20200619"

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     'sqlalchemy-utils>=0.35.0 ; python_version>="3"',
     'sqlalchemy-utils<=0.36.3 ; python_version=="2.7"',
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType
+    "reana-commons>=0.7.0.dev20200602",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Uses the centrall host name for database which will include the
  fully qualified domain name inside the cluster, including the
  namespace enabling RJC to communicate to it from different
  namespaces (closes reanahub/reana#268).