### PR TITLE
models: calculate disk workflow resource usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,13 +15,9 @@ from uuid import uuid4
 
 import pytest
 
-from reana_db.config import DEFAULT_QUOTA_RESOURCES
 from reana_db.models import (
     Resource,
-    ResourceType,
-    ResourceUnit,
     User,
-    UserResource,
     Workflow,
     RunStatus,
 )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,18 +13,19 @@ from uuid import uuid4
 import pytest
 from mock import patch
 
-from reana_db.config import DEFAULT_QUOTA_RESOURCES
 from reana_db.models import (
     ALLOWED_WORKFLOW_STATUS_TRANSITIONS,
     AuditLogAction,
-    Resource,
     ResourceUnit,
+    ResourceType,
     UserTokenStatus,
     UserTokenType,
     Workflow,
     WorkflowResource,
     RunStatus,
 )
+
+from reana_db.utils import get_default_quota_resource
 
 
 def test_workflow_run_number_assignment(db, session, new_user):
@@ -197,9 +198,7 @@ def test_workflow_cpu_quota_usage_update(db, session, run_workflow):
     """Test quota usage update once workflow is finished/stopped/failed."""
     time_elapsed_seconds = 0.5
     workflow = run_workflow(time_elapsed_seconds=time_elapsed_seconds)
-    cpu_resource = Resource.query.filter_by(
-        name=DEFAULT_QUOTA_RESOURCES["cpu"]
-    ).one_or_none()
+    cpu_resource = get_default_quota_resource(ResourceType.cpu.name)
     cpu_milliseconds = (
         WorkflowResource.query.filter_by(
             workflow_id=workflow.id_, resource_id=cpu_resource.id_


### PR DESCRIPTION
closes #93

Steps to test it:

```bash
# Start from a clean DB
$ reana-dev cluster-undeploy && reana-dev cluster-deploy ...

$ kubectl exec -ti deployment/reana-db -- psql -U reana

reana=# select r.type_, wr.quantity_used, wr.workflow_id from __reana.resource as r join __reana.workflow_resource as wr on r.id_ = wr.resource_id;
 type_ | quantity_used | workflow_id 
-------+---------------+-------------
(0 rows)

# run a workflow and wait for it to finish
# 🕐 ... ✅ 

reana=# select r.type_, wr.quantity_used, wr.workflow_id from __reana.resource as r join __reana.workflow_resource as wr on r.id_ = wr.resource_id;
 type_ | quantity_used |             workflow_id              
-------+---------------+--------------------------------------
 cpu   |         24415 | 61a6ce6e-e173-4f66-bc60-34c9af07db81
 disk  |        173734 | 61a6ce6e-e173-4f66-bc60-34c9af07db81
(2 rows)
```