### PR TITLE
models: use powers of 1024 to display size units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 Version master (UNRELEASED)
 ---------------------------
 
-- Adds disk usage retreival methods to user and workflow models.
+- Adds new disk usage retrieval methods using canonical (bytes) and human-readable (KiB) units. (``User``, ``Workflow``)
 
 Version 0.7.0 (2020-10-20)
 --------------------------

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -734,7 +734,7 @@ class ResourceUnit(enum.Enum):
         """Convert bytes usage to human readable string."""
         if bytes_ == 0:
             return "0 Bytes"
-        units = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+        units = ["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
         digits = 2
         k = 1024
         unit_index = int(math.floor(math.log(bytes_) / math.log(k)))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -240,12 +240,12 @@ def test_user_cpu_usage(db, session, new_user, run_workflow):
         ),
         # Bytes VS human readable
         (ResourceUnit.bytes_, 0, "0 Bytes"),
-        (ResourceUnit.bytes_, 1024 * 35, "35 KB"),
-        (ResourceUnit.bytes_, 1024 * 200 + 512, "200.5 KB"),
-        (ResourceUnit.bytes_, 1024 ** 2, "1 MB"),
-        (ResourceUnit.bytes_, 1024 ** 2 + 1024 * 768, "1.75 MB"),
-        (ResourceUnit.bytes_, 1024 ** 3 * 5 + 1024 ** 2 * 100, "5.1 GB"),
-        (ResourceUnit.bytes_, 1024 ** 4 + 1024 ** 3 * 256, "1.25 TB"),
+        (ResourceUnit.bytes_, 1024 * 35, "35 KiB"),
+        (ResourceUnit.bytes_, 1024 * 200 + 512, "200.5 KiB"),
+        (ResourceUnit.bytes_, 1024 ** 2, "1 MiB"),
+        (ResourceUnit.bytes_, 1024 ** 2 + 1024 * 768, "1.75 MiB"),
+        (ResourceUnit.bytes_, 1024 ** 3 * 5 + 1024 ** 2 * 100, "5.1 GiB"),
+        (ResourceUnit.bytes_, 1024 ** 4 + 1024 ** 3 * 256, "1.25 TiB"),
     ],
 )
 def test_human_readable_unit_values(unit, value, human_readable_string):


### PR DESCRIPTION
E.g. "KiB", "MiB", "GiB", etc.

closes reanahub/reana#437

---

```console
$ reana-client quota-show --resource disk               
222.55 KiB out of 8.58 MiB used (3%)
```

![image](https://user-images.githubusercontent.com/8863238/98240683-14269780-1f6a-11eb-80ca-2b1c9b0991f1.png)


![image](https://user-images.githubusercontent.com/8863238/98240652-06711200-1f6a-11eb-9c2b-bac37691ee7f.png)

