### PR TITLE
installation: temporarily pin SQLAlchemy<1.4 

### DIFF
--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a12"
+__version__ = "0.8.0a13"

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,7 @@ setup_requires = [
 install_requires = [
     "alembic>=1.4.2",
     "psycopg2-binary>=2.6.1",
-    'SQLAlchemy>=1.2.7 ; python_version>="3"',
-    'SQLAlchemy>=1.2.7,<1.4.0 ; python_version=="2.7"',
+    "SQLAlchemy>=1.2.7,<1.4.0",
     'sqlalchemy-utils>=0.35.0 ; python_version>="3"',
     'sqlalchemy-utils<=0.36.3 ; python_version=="2.7"',
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType


### PR DESCRIPTION
Issue caused by an imcompatibility between sqlalchemy-utils
and latest SQLAlchemy 1.4 (Fix is already there, but invenio-db needs to be unpinned first)