### PR TITLE
alembic: add revision for job started/finished times

### DIFF
--- a/reana_db/alembic/versions/20201009_1612_ad93dae04483_interactive_sessions.py
+++ b/reana_db/alembic/versions/20201009_1612_ad93dae04483_interactive_sessions.py
@@ -78,7 +78,7 @@ def upgrade():
 
 
 def downgrade():
-    """Downgrade to previous revision (none in this case)."""
+    """Downgrade to c912d4f1e1cc revision."""
     op.add_column(
         "workflow",
         sa.Column("interactive_session", sa.TEXT(), autoincrement=False, nullable=True),

--- a/reana_db/alembic/versions/20210507_1240_4801b98f6408_job_started_and_finished_times.py
+++ b/reana_db/alembic/versions/20210507_1240_4801b98f6408_job_started_and_finished_times.py
@@ -1,0 +1,32 @@
+"""Job started and finished times.
+
+Revision ID: 4801b98f6408
+Revises: ad93dae04483
+Create Date: 2021-05-07 12:40:54.207470
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4801b98f6408"
+down_revision = "ad93dae04483"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade to 4801b98f6408 revision."""
+    op.add_column(
+        "job", sa.Column("finished_at", sa.DateTime(), nullable=True), schema="__reana"
+    )
+    op.add_column(
+        "job", sa.Column("started_at", sa.DateTime(), nullable=True), schema="__reana"
+    )
+
+
+def downgrade():
+    """Downgrade to ad93dae04483 revision."""
+    op.drop_column("job", "started_at", schema="__reana")
+    op.drop_column("job", "finished_at", schema="__reana")


### PR DESCRIPTION
closes #127

To test:
```console
$ kubectl exec -ti deployment/reana-db -- psql -U reana
psql (9.6.2)
Type "help" for help.

reana=# \d __reana.job
                     Table "__reana.job"
       Column       |            Type             | Modifiers 
--------------------+-----------------------------+-----------
...
 finished_at        | timestamp without time zone | 
 started_at         | timestamp without time zone | 
...
reana=# \q

$ kubectl exec deployment/reana-server reana-db alembic history
ad93dae04483 -> 4801b98f6408 (head), Job started and finished times.
c912d4f1e1cc -> ad93dae04483, Interactive sessions.
<base> -> c912d4f1e1cc, Quota tables.

$ kubectl exec deployment/reana-server reana-db alembic current
4801b98f6408 (head)

$ kubectl exec deployment/reana-server reana-db alembic downgrade ad93dae04483
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade 4801b98f6408 -> ad93dae04483, Job started and finished times.

$ kubectl exec -ti deployment/reana-db -- psql -U reana
psql (9.6.2)
Type "help" for help.

reana=# \d __reana.job
                     Table "__reana.job"
       Column       |            Type             | Modifiers 
--------------------+-----------------------------+-----------
...
👀  NO FINISHED_AT AND STARTED_AT!
...
reana=# \q

$ kubectl exec deployment/reana-server reana-db alembic upgrade
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade ad93dae04483 -> 4801b98f6408, Job started and finished times.

$ kubectl exec -ti deployment/reana-db -- psql -U reana
psql (9.6.2)
Type "help" for help.

reana=# \d __reana.job
                     Table "__reana.job"
       Column       |            Type             | Modifiers 
--------------------+-----------------------------+-----------
...
 finished_at        | timestamp without time zone | 
 started_at         | timestamp without time zone | 
...
reana=# \q
```