### PR TITLE
models: store workflow complexity

### DIFF
--- a/reana_db/alembic/versions/20210607_1217_f84e17bd6b18_workflow_complexity.py
+++ b/reana_db/alembic/versions/20210607_1217_f84e17bd6b18_workflow_complexity.py
@@ -1,0 +1,35 @@
+"""Workflow complexity.
+
+Revision ID: f84e17bd6b18
+Revises: 4801b98f6408
+Create Date: 2021-06-07 12:17:47.218408
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "f84e17bd6b18"
+down_revision = "4801b98f6408"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade to f84e17bd6b18 revision."""
+    op.add_column(
+        "workflow",
+        sa.Column(
+            "complexity",
+            postgresql.ARRAY(sa.BigInteger(), dimensions=2),
+            nullable=True,
+            server_default="{}",
+        ),
+        schema="__reana",
+    )
+
+
+def downgrade():
+    """Downgrade to 4801b98f6408 revision."""
+    op.drop_column("workflow", "complexity", schema="__reana")

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -38,6 +38,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy_utils import EncryptedType, JSONType, UUIDType
 from sqlalchemy_utils.models import Timestamp
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
+from sqlalchemy.dialects.postgresql import ARRAY
 
 from reana_db.config import DB_SECRET_KEY, DEFAULT_QUOTA_LIMITS, DEFAULT_QUOTA_RESOURCES
 from reana_db.utils import (
@@ -416,6 +417,7 @@ class Workflow(Base, Timestamp, QuotaBase):
     reana_specification = Column(JSONType)
     input_parameters = Column(JSONType)
     operational_options = Column(JSONType)
+    complexity = Column(ARRAY(BigInteger(), dimensions=2), default=[])
     type_ = Column(String(30))
     logs = Column(String)
     run_started_at = Column(DateTime)
@@ -462,6 +464,7 @@ class Workflow(Base, Timestamp, QuotaBase):
         input_parameters={},
         operational_options={},
         status=RunStatus.created,
+        complexity=[],
         git_ref="",
         git_repo=None,
         git_provider=None,
@@ -477,6 +480,7 @@ class Workflow(Base, Timestamp, QuotaBase):
         self.reana_specification = reana_specification
         self.input_parameters = input_parameters
         self.operational_options = operational_options
+        self.complexity = complexity
         self.type_ = type_
         self.logs = logs or ""
         self.git_ref = git_ref

--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a16"
+__version__ = "0.8.0a17"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'sqlalchemy-utils>=0.35.0 ; python_version>="3"',
     'sqlalchemy-utils<=0.36.3 ; python_version=="2.7"',
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType
-    "reana-commons>=0.8.0a8,<0.9.0",
+    "reana-commons>=0.8.0a14,<0.9.0",
     'websocket-client==0.59.0 ; python_version=="2.7"',  # pin due to py2 support drop
 ]
 


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/358

#### Test alembic revision:

```console
$ kubectl exec deployment/reana-server reana-db alembic history
4801b98f6408 -> f84e17bd6b18 (head), Workflow complexity.
ad93dae04483 -> 4801b98f6408, Job started and finished times.
c912d4f1e1cc -> ad93dae04483, Interactive sessions.
<base> -> c912d4f1e1cc, Quota tables.

$ kubectl exec deployment/reana-server reana-db alembic current
f84e17bd6b18 (head)

$ kubectl exec deployment/reana-server reana-db alembic downgrade 4801b98f6408
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade f84e17bd6b18 -> 4801b98f6408, Workflow complexity.

$ kubectl exec deployment/reana-server reana-db alembic upgrade
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
f84e17bd6b18 (head)
```
You can check the status of PostgreSQL using `psq`l as indicated [here](https://github.com/reanahub/reana-db/pull/128).

⚠️ It works with empty DB (no workflows created). As soon as you create a workflow (`reana-client run`), it gets stuck on downgrade.

`ALTER TABLE __reana.workflow DROP COLUMN complexity;` or `ALTER TABLE __reana.workflow ADD COLUMN mycomplexity VARCHAR NOT NULL DEFAULT '[]';` also gets stuck via `psql` so it seems there is a PostgreSQL problem.