### PR TITLE
models: adjust wf overflow priority to avoid to be 0

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -270,8 +270,11 @@ class User(Base, Timestamp, QuotaBase):
         # to avoid py27 floor division between integers
         running_count = float(running_count)
         if running_count > max_concurrent_workflows:
-            return 0
-        priority = round(1 - running_count / max_concurrent_workflows, 2)
+            return 0.1
+        # we reduce the 10% (* 0.9) to avoid getting a 0 multiplier factor when
+        # `running_count == `max_concurrent_workflows`, thus taking into
+        # account workflow complexity when workflows are requeued.
+        priority = round(1 - (running_count * 0.9) / max_concurrent_workflows, 2)
         return priority
 
     def __repr__(self):

--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a18"
+__version__ = "0.8.0a19"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -307,15 +307,15 @@ def test_should_cleanup_job(
 @pytest.mark.parametrize(
     "running_workflows, REANA_MAX_CONCURRENT_BATCH_WORKFLOWS,  priority",
     [
-        (2, 10, 0.8),
-        (3, 10, 0.7),
-        (4, 10, 0.6),
-        (11, 10, 0),
-        (15, 30, 0.5),
-        (12, 30, 0.6),
-        (30, 30, 0),
-        (17, 50, 0.66),
-        (7, 64, 0.89),
+        (2, 10, 0.82),
+        (3, 10, 0.73),
+        (4, 10, 0.64),
+        (11, 10, 0.1),
+        (15, 30, 0.55),
+        (12, 30, 0.64),
+        (30, 30, 0.1),
+        (17, 50, 0.69),
+        (7, 64, 0.9),
     ],
 )
 def test_get_workflow_overload_priority(


### PR DESCRIPTION
So workflow complexity is still relevant besides user reaching `max_concurrent_workflows`.

closes reanahub/reana-server#381


Check [this comment](https://github.com/reanahub/reana-server/issues/381#issuecomment-863962382) for reference.