### PR TITLE
models: modify workspace_path to store full path

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,6 +4,7 @@ Authors
 The list of contributors in alphabetical order:
 
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
+- `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_
 - `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_

--- a/reana_db/utils.py
+++ b/reana_db/utils.py
@@ -13,16 +13,25 @@ from uuid import UUID
 from sqlalchemy import inspect
 
 
-def build_workspace_path(user_id, workflow_id=None):
+def build_workspace_path(user_id, workflow_id=None, workspace_root_path=None):
     """Build user's workspace relative path.
 
     :param user_id: Owner of the workspace.
     :param workflow_id: Optional parameter, if provided gives the path to the
         workflow workspace instead of just the path to the user workspace.
-    :return: String that represents the workspace relative path.
-        i.e. users/0000/workflows/0034
+    :param workspace_root_path: Optional parameter, if provided changes the
+        root path under which the workflow workspaces are stored.
+    :return: String that represents the workspace absolute path.
+        i.e. /var/reana/users/0000/workflows/0034
     """
-    workspace_path = os.path.join("users", str(user_id), "workflows")
+    from reana_commons.config import SHARED_VOLUME_PATH
+
+    if workspace_root_path:
+        workspace_path = workspace_root_path
+    else:
+        workspace_path = os.path.join(
+            SHARED_VOLUME_PATH, "users", str(user_id), "workflows"
+        )
     if workflow_id:
         workspace_path = os.path.join(workspace_path, str(workflow_id))
 

--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.0a19"
+__version__ = "0.8.0a20"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.0a5,<0.9.0",
+    "pytest-reana>=0.8.0a6,<0.9.0",
 ]
 
 extras_require = {
@@ -43,7 +43,7 @@ install_requires = [
     "SQLAlchemy>=1.2.7,<1.4.0",
     "sqlalchemy-utils>=0.35.0",
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType
-    "reana-commons>=0.8.0a19,<0.9.0",
+    "reana-commons>=0.8.0a21,<0.9.0",
 ]
 
 packages = find_packages()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,9 +10,15 @@
 
 from __future__ import absolute_import, print_function
 
+import os
+
+from reana_commons.config import SHARED_VOLUME_PATH
+
 
 def test_build_workspace_path():
     """Tests for build_workspace_path()."""
     from reana_db.utils import build_workspace_path
 
-    assert build_workspace_path(0) == "users/0/workflows"
+    assert build_workspace_path(0) == os.path.join(
+        SHARED_VOLUME_PATH, "users/0/workflows"
+    )


### PR DESCRIPTION
Quit the dependency of upload-file,remove-file, list-files,mv-files  and download, relying directly on the full-path stored in the database
    
Closes reanahub/reana-db#94