### PR TITLE
utils: use default workspace path instead of shared workspace path  when the workspace root path is not declared

### DIFF
--- a/reana_db/utils.py
+++ b/reana_db/utils.py
@@ -24,13 +24,13 @@ def build_workspace_path(user_id, workflow_id=None, workspace_root_path=None):
     :return: String that represents the workspace absolute path.
         i.e. /var/reana/users/0000/workflows/0034
     """
-    from reana_commons.config import SHARED_VOLUME_PATH
+    from reana_commons.config import DEFAULT_WORKSPACE_PATH
 
     if workspace_root_path:
         workspace_path = workspace_root_path
     else:
         workspace_path = os.path.join(
-            SHARED_VOLUME_PATH, "users", str(user_id), "workflows"
+            DEFAULT_WORKSPACE_PATH, "users", str(user_id), "workflows"
         )
     if workflow_id:
         workspace_path = os.path.join(workspace_path, str(workflow_id))

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     "SQLAlchemy>=1.2.7,<1.4.0",
     "sqlalchemy-utils>=0.35.0",
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType
-    "reana-commons>=0.8.0a21,<0.9.0",
+    "reana-commons>=0.8.0a25,<0.9.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Closes reanahub/reana#532