### PR TITLE
config: adapt quota update policy to helm values

### DIFF
--- a/reana_db/config.py
+++ b/reana_db/config.py
@@ -88,8 +88,6 @@ DEFAULT_QUOTA_LIMITS = {
 """Default CPU (in milliseconds) and disk (in bytes) quota limits."""
 
 
-WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY = os.getenv(
-    "REANA_WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY",
-    f"{QuotaResourceType.cpu},{QuotaResourceType.disk}",
-).split(",")
+policies = os.getenv("REANA_WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY")
+WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY = policies.split(",") if policies else []
 """What quota types to update, if not specified all quotas will be calculated, if empty no quotas will be updated."""

--- a/reana_db/config.py
+++ b/reana_db/config.py
@@ -9,6 +9,7 @@
 """REANA DB configuration."""
 
 import os
+from distutils.util import strtobool
 from enum import Enum
 
 from reana_commons.config import REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES
@@ -91,3 +92,9 @@ DEFAULT_QUOTA_LIMITS = {
 policies = os.getenv("REANA_WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY")
 WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY = policies.split(",") if policies else []
 """What quota types to update, if not specified all quotas will be calculated, if empty no quotas will be updated."""
+
+
+CRONJOB_DISK_QUOTA_UPDATE_POLICY = strtobool(
+    os.getenv("REANA_CRONJOB_DISK_QUOTA_UPDATE_POLICY", "false")
+)
+"""Whether to run the cronjob disk quota updater."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 import mock
 
+from reana_db.config import QuotaResourceType
 from reana_db.models import (
     ALLOWED_WORKFLOW_STATUS_TRANSITIONS,
     AuditLogAction,
@@ -25,7 +26,6 @@ from reana_db.models import (
     WorkflowResource,
     RunStatus,
 )
-
 from reana_db.utils import get_default_quota_resource
 
 
@@ -209,6 +209,10 @@ def test_access_token(db, session, new_user):
 @mock.patch(
     "reana_commons.utils.get_disk_usage", return_value=[{"size": {"raw": "128"}}]
 )
+@mock.patch(
+    "reana_db.models.WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY",
+    [QuotaResourceType.cpu.value, QuotaResourceType.disk.value],
+)
 def test_workflow_cpu_quota_usage_update(db, session, run_workflow):
     """Test quota usage update once workflow is finished/stopped/failed."""
     time_elapsed_seconds = 0.5
@@ -224,6 +228,14 @@ def test_workflow_cpu_quota_usage_update(db, session, run_workflow):
     assert cpu_milliseconds >= time_elapsed_seconds * 1000
 
 
+@mock.patch(
+    "reana_db.models.WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY",
+    [QuotaResourceType.cpu.value, QuotaResourceType.disk.value],
+)
+@mock.patch(
+    "reana_db.utils.WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY",
+    [QuotaResourceType.cpu.value, QuotaResourceType.disk.value],
+)
 @mock.patch(
     "reana_commons.utils.get_disk_usage", return_value=[{"size": {"raw": "128"}}]
 )


### PR DESCRIPTION
Adapt assignment logic to avoid a list with an empty string `[""]`
when the policy coming from Helm is empty.

closes reanahub/reana#562