### PR TITLE
quota: allow calculating cpu quota periodically

### DIFF
--- a/reana_db/cli.py
+++ b/reana_db/cli.py
@@ -242,11 +242,11 @@ def resource_usage_update() -> None:
             elif resource == ResourceType.cpu:
                 update_users_cpu_quota()
             click.secho(
-                f"Users {resource.value} quota usage updated successfully.", fg="green"
+                f"Users {resource.name} quota usage updated successfully.", fg="green"
             )
         except Exception as e:
             click.secho(
-                f"[ERROR]: An error occurred when updating users {resource} quota usage: {repr(e)}",
+                f"[ERROR]: An error occurred when updating users {resource.name} quota usage: {repr(e)}",
                 fg="red",
             )
             sys.exit(1)

--- a/reana_db/cli.py
+++ b/reana_db/cli.py
@@ -15,9 +15,8 @@ import click
 from alembic import command
 from alembic import config as alembic_config
 
-from reana_db.config import QuotaResourceType
 from reana_db.database import init_db
-from reana_db.models import Resource, Workflow
+from reana_db.models import Resource, ResourceType, Workflow
 from reana_db.utils import (
     store_workflow_disk_quota,
     update_users_cpu_quota,
@@ -233,14 +232,14 @@ def create_default_resources():
 def resource_usage_update() -> None:
     """Update users disk and CPU quotas."""
 
-    def _resource_usage_update(resource: QuotaResourceType) -> None:
+    def _resource_usage_update(resource: ResourceType) -> None:
         """Update users resource quota usage."""
         try:
-            if resource == QuotaResourceType.disk:
+            if resource == ResourceType.disk:
                 update_users_disk_quota()
                 for workflow in Workflow.query.all():
                     store_workflow_disk_quota(workflow)
-            elif resource == QuotaResourceType.cpu:
+            elif resource == ResourceType.cpu:
                 update_users_cpu_quota()
             click.secho(
                 f"Users {resource.value} quota usage updated successfully.", fg="green"
@@ -252,5 +251,5 @@ def resource_usage_update() -> None:
             )
             sys.exit(1)
 
-    _resource_usage_update(QuotaResourceType.disk)
-    _resource_usage_update(QuotaResourceType.cpu)
+    _resource_usage_update(ResourceType.disk)
+    _resource_usage_update(ResourceType.cpu)

--- a/reana_db/config.py
+++ b/reana_db/config.py
@@ -94,7 +94,7 @@ WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY = policies.split(",") if policies else 
 """What quota types to update, if not specified all quotas will be calculated, if empty no quotas will be updated."""
 
 
-CRONJOB_DISK_QUOTA_UPDATE_POLICY = strtobool(
-    os.getenv("REANA_CRONJOB_DISK_QUOTA_UPDATE_POLICY", "false")
+PERIODIC_RESOURCE_QUOTA_UPDATE_POLICY = strtobool(
+    os.getenv("REANA_PERIODIC_RESOURCE_QUOTA_UPDATE_POLICY", "false")
 )
-"""Whether to run the cronjob disk quota updater."""
+"""Whether to run the periodic (cronjob) resource quota updater."""

--- a/reana_db/config.py
+++ b/reana_db/config.py
@@ -10,7 +10,6 @@
 
 import os
 from distutils.util import strtobool
-from enum import Enum
 
 from reana_commons.config import REANA_INFRASTRUCTURE_COMPONENTS_HOSTNAMES
 
@@ -63,18 +62,6 @@ SQLALCHEMY_POOL_SIZE = int(float(os.getenv("SQLALCHEMY_POOL_SIZE", 5)))
 
 SQLALCHEMY_POOL_TIMEOUT = int(float(os.getenv("SQLALCHEMY_POOL_TIMEOUT", 30)))
 """How many seconds to wait when retrieving a new connection from the pool?"""
-
-
-class QuotaResourceType(str, Enum):
-    """Possible quota policies.
-
-    Example:
-        QuotaPolicy.cpu == "cpu"  # True
-    """
-
-    cpu = "cpu"
-    disk = "disk"
-
 
 DEFAULT_QUOTA_RESOURCES = {
     "cpu": "processing time",

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -51,7 +51,6 @@ from reana_db.config import (
     DEFAULT_QUOTA_LIMITS,
     DEFAULT_QUOTA_RESOURCES,
     WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY,
-    QuotaResourceType,
 )
 from reana_db.utils import (
     build_workspace_path,
@@ -690,13 +689,13 @@ def workflow_status_change_listener(workflow, new_status, old_status, initiator)
     from .database import Session
 
     def _update_disk_quota(workflow):
-        if QuotaResourceType.disk not in WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY:
+        if ResourceType.disk.name not in WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY:
             return
         update_users_disk_quota(user=workflow.owner)
         store_workflow_disk_quota(workflow)
 
     def _update_cpu_quota(workflow):
-        if QuotaResourceType.cpu not in WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY:
+        if ResourceType.cpu.name not in WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY:
             return
 
         update_workflow_cpu_quota(workflow=workflow)

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -686,7 +686,6 @@ class Workflow(Base, Timestamp, QuotaBase):
 @event.listens_for(Workflow.status, "set")
 def workflow_status_change_listener(workflow, new_status, old_status, initiator):
     """Workflow status change listener."""
-    from .database import Session
 
     def _update_disk_quota(workflow):
         if ResourceType.disk.name not in WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def new_user(session, db):
 
 @pytest.fixture
 def run_workflow(session, new_user):
-    """Mocked workflow run factory."""
+    """Mock workflow run factory."""
 
     def _run_workflow(time_elapsed_seconds=0.5, finish=True):
         """Mock a workflow run."""


### PR DESCRIPTION
* moves cpu quota calculation logic into a function
* renames cli `disk-usage-update` cmd to `resource-usage-update` and includes cpu logic
* adds `update_users_cpu_quota` func to calculate all users' cpu quota
* adds tests covering functionality and various quota policy scenarios

closes https://github.com/reanahub/reana/issues/605