### PR TITLE
models: change percentage ranges for calculating the quota health status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.0 (UNRELEASED)
 ---------------------------
 
 - Adds new ``launcher_url`` column to the ``Workflow`` table to store the remote origin of workflows submitted via Launch on REANA.
+- Changes percentage ranges for calculating the quota health status.
 
 Version 0.8.2 (2022-02-23)
 ---------------------------

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -79,8 +79,8 @@ class QuotaBase:
             health = QuotaHealth.healthy
             if limit:
                 percentage = usage / limit * 100
-                if percentage >= 60:
-                    if percentage >= 85:
+                if percentage >= 80:
+                    if percentage >= 100:
                         health = QuotaHealth.critical
                     else:
                         health = QuotaHealth.warning


### PR DESCRIPTION
closes https://github.com/reanahub/reana-ui/issues/160

Change quota health status calculation to follow a traffic light analogy:

  -  healthy (green), usage below <80%;
  -  warning(yellow/brown), usage above 80% and below 100%;
  -  critical (red), usage above 100%.