### PR TITLE
models: add workspace retention rules table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.0 (UNRELEASED)
 ---------------------------
 
 - Adds new ``launcher_url`` column to the ``Workflow`` table to store the remote origin of workflows submitted via Launch on REANA.
+- Adds new ``WorkspaceRetentionRule`` table to store workspace file retention rules.
 - Adds a limit to the number of times a workflow can be restarted.
 - Changes percentage ranges for calculating the quota health status.
 

--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0a6"
+__version__ = "0.9.0a7"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
     "SQLAlchemy>=1.2.7,<1.4.0",
     "sqlalchemy-utils>=0.35.0",
     "cryptography>=2.9.2",  # Required by sqlalchemy_utils.EncryptedType
-    "reana-commons>=0.9.0a1,<0.10.0",
+    "reana-commons>=0.9.0a10,<0.10.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
closes https://github.com/reanahub/reana-db/issues/172

To test:

- `kubectl exec -i -t deployment/reana-server -c rest-api -- invenio shell`:
```
from reana_db.models import Workflow, WorkspaceRetentionRule, WorkspaceRetentionRuleStatus
from reana_db.utils import update_workspace_retention_rules
from reana_db.database import Session
from datetime import datetime
s = Session()

workflow_id = Workflow.query.first().id_
workspace_files = "myfetched/**/*.root"
retention_days = 1
apply_on = None

# Insert a single rule
wr = WorkspaceRetentionRule(workflow_id=workflow_id, workspace_files=workspace_files, retention_days=retention_days)
s.add(wr)
s.commit()

# Update a single rule
wr.status = WorkspaceRetentionRuleStatus.inactive
s.add(wr)
s.commit()

# Inspect audit logs
wr.audit_logs.all()

# Insert multiple rules while creating the workflow
w = Workflow.query.first()
retention_rules = [
    {
        "workspace_files": "myfiltered/*.root",
        "retention_days": 7
    },
    {
        "workspace_files": "myfits/",
        "retention_days": 30
    },
]
w.set_workspace_retention_rules(retention_rules)

# Update multiple rules
wr_all = WorkspaceRetentionRule.query.filter(WorkspaceRetentionRule.workflow_id == workflow_id).all()
for rule in wr_all:
    rule.status = WorkspaceRetentionRuleStatus.applied
    s.add(rule)
s.commit()

# Update all workflow rules
workflow = Workflow.query.first()
workflow.inactivate_workspace_retention_rules()
workflow.activate_workspace_retention_rules()

# Try to transit to a wrong status
update_workspace_retention_rules(workflow, WorkspaceRetentionRuleStatus.created)
```