### PR TITLE
models: limit the number of restarts of a workflow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.0 (UNRELEASED)
 ---------------------------
 
 - Adds new ``launcher_url`` column to the ``Workflow`` table to store the remote origin of workflows submitted via Launch on REANA.
+- Adds a limit to the number of times a workflow can be restarted.
 - Changes percentage ranges for calculating the quota health status.
 
 Version 0.8.2 (2022-02-23)

--- a/reana_db/config.py
+++ b/reana_db/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -85,3 +85,6 @@ PERIODIC_RESOURCE_QUOTA_UPDATE_POLICY = strtobool(
     os.getenv("REANA_PERIODIC_RESOURCE_QUOTA_UPDATE_POLICY", "false")
 )
 """Whether to run the periodic (cronjob) resource quota updater."""
+
+LIMIT_RESTARTS = 9
+"""Maximum number of times a workflow can be restarted."""


### PR DESCRIPTION
Considering issue #173, the limit is currently set to permit at most
nine restarts.

How to test: see #173