### PR TITLE
alembic: add migration for workspace retention rules

### DIFF
--- a/reana_db/alembic/versions/20220711_1301_b92fe567be5b_retention_rules.py
+++ b/reana_db/alembic/versions/20220711_1301_b92fe567be5b_retention_rules.py
@@ -1,0 +1,88 @@
+"""Retention rules.
+
+Revision ID: b92fe567be5b
+Revises: d34f3905043c
+Create Date: 2022-07-11 13:01:19.179610
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+
+# revision identifiers, used by Alembic.
+revision = "b92fe567be5b"
+down_revision = "d34f3905043c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade to b92fe567be5b revision."""
+    op.create_table(
+        "workspace_retention_rule",
+        sa.Column("id_", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column(
+            "workflow_id",
+            sqlalchemy_utils.types.uuid.UUIDType(),
+            nullable=False,
+        ),
+        sa.Column("workspace_files", sa.String(length=255), nullable=False),
+        sa.Column("retention_days", sa.Integer(), nullable=False),
+        sa.Column("apply_on", sa.DateTime(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "created",
+                "active",
+                "inactive",
+                "applied",
+                name="workspaceretentionrulestatus",
+            ),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["__reana.workflow.id_"],
+        ),
+        sa.PrimaryKeyConstraint("id_"),
+        sa.UniqueConstraint(
+            "workflow_id", "workspace_files", name="_workspace_retention_rule_uc"
+        ),
+        schema="__reana",
+    )
+    op.create_table(
+        "workspace_retention_audit_log",
+        sa.Column(
+            "workspace_retention_rule_id",
+            sqlalchemy_utils.types.uuid.UUIDType(),
+            nullable=False,
+        ),
+        sa.Column(
+            "timestamp", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "action",
+            sa.Enum(
+                "created",
+                "active",
+                "inactive",
+                "applied",
+                name="workspaceretentionrulestatus",
+            ),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_retention_rule_id"],
+            ["__reana.workspace_retention_rule.id_"],
+        ),
+        sa.PrimaryKeyConstraint("workspace_retention_rule_id", "timestamp", "action"),
+        schema="__reana",
+    )
+
+
+def downgrade():
+    """Downgrade to d34f3905043c revision."""
+    op.drop_table("workspace_retention_audit_log", schema="__reana")
+    op.drop_table("workspace_retention_rule", schema="__reana")
+    sa.Enum(name="workspaceretentionrulestatus").drop(op.get_bind())


### PR DESCRIPTION
Closes #175

How to test:
1. Deploy the previous version of the cluster
```diff
--- a/helm/configurations/values-dev.yaml
+++ b/helm/configurations/values-dev.yaml
@@ -2,25 +2,25 @@
 
 components:
     reana_server:
-      image: reanahub/reana-server
+      image: reanahub/reana-server:0.9.0-alpha.5
       environment:
         REANA_SCHEDULER_REQUEUE_SLEEP: 2
         REANA_RATELIMIT_SLOW: "5 per second"
     reana_workflow_controller:
-      image: reanahub/reana-workflow-controller
+      image: reanahub/reana-workflow-controller:0.9.0-alpha.5
       environment:
         REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES: failed
     reana_workflow_engine_cwl:
-      image: reanahub/reana-workflow-engine-cwl
+      image: reanahub/reana-workflow-engine-cwl:0.9.0-alpha.4
     reana_workflow_engine_yadage:
-      image: reanahub/reana-workflow-engine-yadage
+      image: reanahub/reana-workflow-engine-yadage:0.9.0-alpha.4
     reana_workflow_engine_serial:
-      image: reanahub/reana-workflow-engine-serial
+      image: reanahub/reana-workflow-engine-serial:0.9.0-alpha.4
     reana_workflow_engine_snakemake:
-      image: reanahub/reana-workflow-engine-snakemake
+      image: reanahub/reana-workflow-engine-snakemake:0.9.0-alpha.4
     reana_job_controller:
-      image: reanahub/reana-job-controller
+      image: reanahub/reana-job-controller:0.9.0-alpha.5
     reana_message_broker:
-      image: reanahub/reana-message-broker
+      image: reanahub/reana-message-broker:0.9.0-alpha.1
     reana_ui:
-      image: reanahub/reana-ui
+      image: reanahub/reana-ui:0.9.0-alpha.5
```
2. Use `helm upgrade` to upgrade to the latest version of the cluster
3. Check that the current DB version is `d34f3905043c`
```console
$ kubectl exec -it deployment/reana-server -- reana-db alembic current
Defaulted container "rest-api" out of: rest-api, scheduler
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
d34f3905043c
```
4. Update the DB to the latest version
```console
$ kubectl exec -it deployment/reana-server -- reana-db alembic upgrade 
Defaulted container "rest-api" out of: rest-api, scheduler
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade d34f3905043c -> b92fe567be5b, Retention rules
```
5. Launch/execute some workflows and check that retention rules are correctly handled
6. Downgrade the DB to the previous version to check that the downgrade migration works correctly