### PR TITLE
models: always calculate disk usage for Workflow.get_workspace_disk_usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds new ``WorkspaceRetentionRule`` table to store workspace file retention rules.
 - Adds a limit to the number of times a workflow can be restarted.
 - Changes percentage ranges for calculating the quota health status.
+- Changes ``Workflow.get_workspace_disk_usage`` to calculate disk usage and not use the usage values from database.
 
 Version 0.8.2 (2022-02-23)
 ---------------------------

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -609,29 +609,14 @@ class Workflow(Base, Timestamp, QuotaBase):
         """Retrieve disk usage information of a workspace."""
         from functools import partial
 
-        if not summarize:
-            # size break down per directory so we can't query DB (`r-client du`)
-            return get_disk_usage(
-                self.workspace_path,
-                summarize,
-                search,
-                to_human_readable_units=partial(
-                    ResourceUnit.human_readable_unit, ResourceUnit.bytes_
-                ),
-            )
-
-        disk_usage = self.get_quota_usage().get("disk", {}).get("usage", {})
-        if not disk_usage:
-            # recalculate disk workflow resource
-            workflow_resource = store_workflow_disk_quota(self)
-            disk_usage = dict(
-                raw=workflow_resource.quota_used,
-                to_human_readable_units=ResourceUnit.human_readable_unit(
-                    ResourceUnit.bytes_, workflow_resource.quota_used
-                ),
-            )
-
-        return [{"name": "", "size": disk_usage}]
+        return get_disk_usage(
+            self.workspace_path,
+            summarize,
+            search,
+            to_human_readable_units=partial(
+                ResourceUnit.human_readable_unit, ResourceUnit.bytes_
+            ),
+        )
 
     def set_workspace_retention_rules(self, rules: List[Dict[str, str]]):
         """Set workspace retention rules for the workflow."""


### PR DESCRIPTION
closes reanahub/reana-server#521

## How to test?

0. Try reproducing an error from the issue with disabled quota.

```diff
diff --git a/helm/reana/values.yaml b/helm/reana/values.yaml
index 487683b..e2b51ed 100644
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -142,7 +142,7 @@ traefik:

 # Quota
 quota:
-  enabled: true
+  enabled: false
   periodic_update_policy: "{{ .Values.quota.disk_update }}"
   workflow_termination_update_policy: "{{ .Values.quota.termination_update_policy }}"
   # backward compatibility
```

1. Keep disabled quotas. Checkout the PR, run `reana-dev git-submodule --update`
2. Try to reproduce the issue again, it should not be possible