### PR TITLE
models: deactivate retention rules when workflow is deleted

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -771,6 +771,7 @@ def workflow_status_change_listener(workflow, new_status, old_status, initiator)
         _update_cpu_quota(workflow)
         _update_disk_quota(workflow)
     elif new_status in [RunStatus.deleted]:
+        workflow.inactivate_workspace_retention_rules()
         _update_disk_quota(workflow)
 
     return new_status

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -124,6 +124,30 @@ def test_workflow_retention_rules(db, session, new_user):
     assert "duplicate key value violates unique constraint" in e.value.args[0]
 
 
+# def _test_when_workflows_delete_workspace_retention_rules_inactivated(
+#     db, session, new_user
+# ):
+#     retention_rules = [{"workspace_files": "**/*.root", "retention_days": 1}]
+#     workflow = Workflow(
+#         id_=str(uuid4()),
+#         name="workflow",
+#         owner_id=new_user.id_,
+#         reana_specification=[],
+#         type_="serial",
+#         logs="",
+#     )
+#     session.add(workflow)
+#     session.commit()
+#
+#     workflow.set_workspace_retention_rules(retention_rules)
+#     workflow.status = RunStatus.deleted
+#     session.add(workflow)
+#     session.commit()
+#
+#     for rule in workflow.retention_rules.all():
+#         assert rule.status == WorkspaceRetentionRuleStatus.inactive
+
+
 @mock.patch(
     "reana_commons.utils.get_disk_usage", return_value=[{"size": {"raw": "128"}}]
 )


### PR DESCRIPTION
closes #179

How to test?

1. Add some retention rules (e.g root6 workflow):

```diff
diff --git a/reana.yaml b/reana.yaml
index 9b13d45..59c80db 100644
--- a/reana.yaml
+++ b/reana.yaml
@@ -21,6 +21,12 @@ workflow:
         kubernetes_memory_limit: '256Mi'
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")'
+
+workspace:
+  retention_days:
+    results/*.root: 1
+    code/*.C: 1
+
 outputs:
   files:
     - results/plot.png
```

2. Run workflow
3. Delete workflow
4. SSH into the r-server container and start python interpreter:

```python
root@reana-server-f5976658d-wbp7t:/code# python
Python 3.8.13 (default, Jul 13 2022, 05:54:24)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from reana_db.database import Session
>>> from reana_db.models import WorkspaceRetentionRule
>>> WorkspaceRetentionRule.query.all()
[<WorkspaceRetentionRule a2dfecc6-c6c6-4cc7-b2f5-e354972c769b **/* 365 WorkspaceRetentionRuleStatus.inactive>, <WorkspaceRetentionRule a2dfecc6-c6c6-4cc7-b2f5-e354972c769b results/*.root 1 WorkspaceRetentionRuleStatus.inactive>, <WorkspaceRetentionRule a2dfecc6-c6c6-4cc7-b2f5-e354972c769b code/*.C 1 WorkspaceRetentionRuleStatus.inactive>, <WorkspaceRetentionRule b94b0928-8ded-489c-9b53-891542d09e8e code/*.C 1 WorkspaceRetentionRuleStatus.inactive>, <WorkspaceRetentionRule b94b0928-8ded-489c-9b53-891542d09e8e results/*.root 1 WorkspaceRetentionRuleStatus.inactive>, <WorkspaceRetentionRule b94b0928-8ded-489c-9b53-891542d09e8e **/* 365 WorkspaceRetentionRuleStatus.inactive>]
>>>
```

As you can see, rules are deactivated.