### PR TITLE
models: add new allowed transition for retention rules

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -894,6 +894,7 @@ ALLOWED_WORKSPACE_RETENTION_RULE_STATUS_TRANSITIONS = [
     (WorkspaceRetentionRuleStatus.inactive, WorkspaceRetentionRuleStatus.active),
     # Pending
     (WorkspaceRetentionRuleStatus.pending, WorkspaceRetentionRuleStatus.applied),
+    (WorkspaceRetentionRuleStatus.pending, WorkspaceRetentionRuleStatus.active),
     # Applied
     (WorkspaceRetentionRuleStatus.applied, WorkspaceRetentionRuleStatus.applied),
 ]

--- a/reana_db/version.py
+++ b/reana_db/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0a8"
+__version__ = "0.9.0a9"


### PR DESCRIPTION
This commit adds a new allowed transition from the status `pending` to the status `active`. This transition is needed when there are errors while applying the rule, so that it can be applied again in the future.

Closes reanahub/reana-server#559