### PR TITLE
models: avoid dividing by zero in priority workflow calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.2 (UNRELEASED)
+--------------------------
+
+- Fixes the workflow priority calculation to avoid workflows stuck in the ``queued`` status when the number of allowed concurrent workflow is set to zero.
+
 Version 0.9.1 (2023-01-18)
 --------------------------
 

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -278,7 +278,7 @@ class User(Base, Timestamp, QuotaBase):
                 Workflow.status == RunStatus.running,
             )
         ).count()
-        if running_count > max_concurrent_workflows:
+        if running_count >= max_concurrent_workflows:
             return 0.1
         # we reduce the 10% (* 0.9) to avoid getting a 0 multiplier factor when
         # `running_count == `max_concurrent_workflows`, thus taking into


### PR DESCRIPTION
Fix the workflow priority calculation to avoid dividing by zero and
causing workflows to be stuck in the ``queued`` status when the number
of allowed concurrent workflow is set to zero. The issue only affects
the "balanced" scheduling strategy.

Closes #195
