### PR TITLE
quota: improve performance of quota updater

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -60,6 +60,7 @@ from reana_db.config import (
 from reana_db.utils import (
     build_workspace_path,
     store_workflow_disk_quota,
+    update_users_cpu_quota,
     update_users_disk_quota,
     update_workflow_cpu_quota,
     update_workspace_retention_rules,
@@ -768,6 +769,7 @@ def workflow_status_change_listener(workflow, new_status, old_status, initiator)
 
         try:
             update_workflow_cpu_quota(workflow=workflow)
+            update_users_cpu_quota(user=workflow.owner)
         except Exception as e:
             logging.error(f"Failed to update cpu quota: \n{e}\nContinuing...")
 


### PR DESCRIPTION
quota: improve performance of quota updater

Improve the performance of the quota updater by "expunging" all
workflows before starting to update quotas, as the Workflow table does
not need to be modified, thus making commits much faster. Also refactor
the various update functions to make their behaviour consistent with
each other.

Partially addresses https://github.com/reanahub/reana-db/issues/193