### PR TITLE
models: replace workflow.run_number with generation and restart number

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,7 @@ The list of contributors in alphabetical order:
 - `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_
+- `Giuseppe Steduto <https://orcid.org/0009-0002-1258-8553>`_
 - `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
 - `Leticia Wanderley <https://orcid.org/0000-0003-4649-6630>`_
 - `Marco Donadoni <https://orcid.org/0000-0003-2922-5505>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 0.9.3 (UNRELEASED)
+--------------------------
+- Changes the ``Workflow`` table to replace the ``run_number`` column with two new columns ``run_number_major`` and ``run_number_minor``, in order to allow for more than 9 restarts.
+
 Version 0.9.2 (2023-09-26)
 --------------------------
 

--- a/reana_db/alembic/versions/20231002_1208_b85c3e601de4_separate_run_and_restart_number.py
+++ b/reana_db/alembic/versions/20231002_1208_b85c3e601de4_separate_run_and_restart_number.py
@@ -1,0 +1,114 @@
+"""Separate run number into major and minor run numbers.
+
+Revision ID: b85c3e601de4
+Revises: 377cfbfccf75
+Create Date: 2023-10-02 12:08:18.292490
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b85c3e601de4"
+down_revision = "377cfbfccf75"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade to b85c3e601de4 revision."""
+    # Add new columns (run_number_major, run_number_minor)
+    op.add_column(
+        "workflow", sa.Column("run_number_major", sa.Integer()), schema="__reana"
+    )
+    op.add_column(
+        "workflow",
+        sa.Column("run_number_minor", sa.Integer(), default=0),
+        schema="__reana",
+    )
+
+    # Data migration (split run_number into run_number_major and run_number_minor)
+    op.get_bind().execute(
+        sa.text(
+            "UPDATE __reana.workflow"
+            " SET run_number_major = FLOOR(run_number), "
+            " run_number_minor = (run_number - FLOOR(run_number)) * 10"
+        ),
+    )
+
+    # Delete old constraint
+    op.drop_constraint("_user_workflow_run_uc", "workflow", schema="__reana")
+
+    # Drop old run_number column
+    op.drop_column("workflow", "run_number", schema="__reana")
+
+    # Add new constraint (the primary key is not run_number anymore, but with major and minor run number
+    op.create_unique_constraint(
+        "_user_workflow_run_uc",
+        "workflow",
+        ["name", "owner_id", "run_number_major", "run_number_minor"],
+        schema="__reana",
+    )
+
+    # Update run_number_minor for workflows that have been restarted more than 10 times
+    # (thus erroneously having the following run_number_major), in case some of them
+    # were created before the limit on 9 restarts was introduced.
+    op.get_bind().execute(
+        sa.text(
+            """
+            UPDATE __reana.workflow AS w
+            SET
+                run_number_major = to_be_updated.new_major_run_number,
+                run_number_minor = (w.run_number_minor + (w.run_number_major - to_be_updated.new_major_run_number) * 10)
+            FROM (
+                SELECT MIN(w1.run_number_major) - 1 AS new_major_run_number, w1.workspace_path
+                FROM __reana.workflow w1
+                WHERE w1.restart AND w1.run_number_minor = 0
+                GROUP BY w1.workspace_path
+            ) AS to_be_updated
+            WHERE w.workspace_path = to_be_updated.workspace_path
+            """
+        ),
+    )
+
+
+def downgrade():
+    """Downgrade to 377cfbfccf75 revision."""
+    # Revert constraint
+    op.drop_constraint("_user_workflow_run_uc", "workflow", schema="__reana")
+
+    # Add old run_number column back
+    op.add_column("workflow", sa.Column("run_number", sa.Float()), schema="__reana")
+
+    # Check that there are no workflows discarded more than 10 times
+    # This is because of the way the info about restarts is stored in
+    # the run_number column (see https://github.com/reanahub/reana-db/issues/186)
+    restarted_ten_times = (
+        op.get_bind()
+        .execute("SELECT COUNT(*) FROM __reana.workflow WHERE run_number_minor >= 10")
+        .fetchone()[0]
+    )
+    if restarted_ten_times != 0:
+        raise ValueError(
+            "Cannot migrate database because some workflows have been restarted 10 or more times,"
+            " and the previous database revision only supports up to 9 restarts."
+            " If you want to downgrade, you should manually delete them."
+        )
+
+    # Data migration (combine run_number_major and restart_number back to run_number)
+    op.get_bind().execute(
+        "UPDATE __reana.workflow SET run_number=run_number_major+(run_number_minor * 1.0 /10)"
+    )
+
+    # Drop new columns
+    op.drop_column("workflow", "run_number_major", schema="__reana")
+    op.drop_column("workflow", "run_number_minor", schema="__reana")
+
+    # Restore old constraint
+    op.create_unique_constraint(
+        "_user_workflow_run_uc",
+        "workflow",
+        ["name", "owner_id", "run_number"],
+        schema="__reana",
+    )

--- a/reana_db/config.py
+++ b/reana_db/config.py
@@ -85,6 +85,3 @@ PERIODIC_RESOURCE_QUOTA_UPDATE_POLICY = strtobool(
     os.getenv("REANA_PERIODIC_RESOURCE_QUOTA_UPDATE_POLICY", "false")
 )
 """Whether to run the periodic (cronjob) resource quota updater."""
-
-LIMIT_RESTARTS = 9
-"""Maximum number of times a workflow can be restarted."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,7 +51,9 @@ def test_workflow_run_number_assignment(db, session, new_user):
     )
     session.add(first_workflow)
     session.commit()
-    assert first_workflow.run_number == 1
+    assert first_workflow.run_number == "1"
+    assert first_workflow.run_number_major == 1
+    assert first_workflow.run_number_minor == 0
     second_workflow = Workflow(
         id_=str(uuid4()),
         name=workflow_name,
@@ -62,7 +64,9 @@ def test_workflow_run_number_assignment(db, session, new_user):
     )
     session.add(second_workflow)
     session.commit()
-    assert second_workflow.run_number == 2
+    assert second_workflow.run_number == "2"
+    assert second_workflow.run_number_major == 2
+    assert second_workflow.run_number_minor == 0
     first_workflow_restart = Workflow(
         id_=str(uuid4()),
         name=workflow_name,
@@ -75,7 +79,9 @@ def test_workflow_run_number_assignment(db, session, new_user):
     )
     session.add(first_workflow_restart)
     session.commit()
-    assert first_workflow_restart.run_number == 1.1
+    assert first_workflow_restart.run_number == "1.1"
+    assert first_workflow_restart.run_number_major == 1
+    assert first_workflow_restart.run_number_minor == 1
     first_workflow_second_restart = Workflow(
         id_=str(uuid4()),
         name=workflow_name,
@@ -88,7 +94,9 @@ def test_workflow_run_number_assignment(db, session, new_user):
     )
     session.add(first_workflow_second_restart)
     session.commit()
-    assert first_workflow_second_restart.run_number == 1.2
+    assert first_workflow_second_restart.run_number == "1.2"
+    assert first_workflow_second_restart.run_number_major == 1
+    assert first_workflow_second_restart.run_number_minor == 2
 
 
 def test_workflow_retention_rules(db, session, new_user):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,27 @@ import pytest
 from reana_commons.config import SHARED_VOLUME_PATH
 
 from reana_db.models import Workflow
-from reana_db.utils import _get_workflow_with_uuid_or_name
+from reana_db.utils import _get_workflow_with_uuid_or_name, split_run_number
+
+
+@pytest.mark.parametrize(
+    "run_number, run_number_major, run_number_minor",
+    [
+        ("1", 1, 0),
+        ("156.12", 156, 12),
+        ("2.4", 2, 4),
+        (3.22, 3, 22),
+        pytest.param(
+            "1.2.3",
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+        ),
+    ],
+)
+def test_split_run_number(run_number, run_number_major, run_number_minor):
+    """Tests for split_run_number()."""
+    assert split_run_number(run_number) == (run_number_major, run_number_minor)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Change the workflow table to split the run_number into two integers: one referring to the generation of the workflows, and the other one referring to the restart number, thus removing the limit of 9 restarts.

Closes #186.

---

To test the PR, these quick scripts might be come in handy:
1) Run the specified number of workflows on REANA (default 15), to be run from a workflow directory (such as roofit).
```shell
#!/bin/bash

# Set the default number of runs to 15 if no argument is passed
NUM_RUNS=${1:-15}

# Run the setup environment command
eval $(reana-dev client-setup-environment)

# Run the workflow the specified number of times
for (( i=1; i<=NUM_RUNS; i++ ))
do
  echo "Starting run $i of $NUM_RUNS..."
  reana-client run -w root6-roofit
  echo "Run $i submitted."
done
```

2) Restart a specific generation of the roofit demo workflow (default `1`) a certain number of times (default `15`). `./restart.sh 50 3` will restart `root6-roofit.3` 50 times.
```shell
#!/bin/bash

# Set the default number of runs to 15 if no argument is passed
NUM_RUNS=${1:-15}
TO_RESTART=${2:-1}

# Run the setup environment command
eval $(reana-dev client-setup-environment)

# Run the workflow the specified number of times
for (( i=1; i<=NUM_RUNS; i++ ))
do
  echo "Starting restart $i of $NUM_RUNS..."
  reana-client restart -w root6-roofit.$TO_RESTART
  echo "Restart $i submitted."
done
```