### PR TITLE
tests: allow execution of selected pytests only

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -79,6 +79,7 @@ check_sphinx () {
 check_pytest () {
     clean_old_db_container
     start_db_container
+    trap clean_old_db_container SIGINT SIGTERM SIGSEGV ERR
     python setup.py test
     stop_db_container
 }


### PR DESCRIPTION
Allows execution of selected pytests via PYTESTARG environment variable. Example:

```
$ PYTESTARG=tests/test_version.py ./run-tests.sh --check-pytest
```

Closes reanahub/reana#755.