### PR TITLE
deprecations setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -98,7 +98,7 @@ check_pytest () {
     clean_old_db_container
     start_db_container
     trap clean_old_db_container SIGINT SIGTERM SIGSEGV ERR
-    python setup.py test
+    pytest
     stop_db_container
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "pytest-reana>=0.95.0a2,<0.96.0",
-]
-
 extras_require = {
     "docs": [
         "myst-parser",
@@ -29,7 +25,9 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
         "sphinx-click>=1.0.4",
     ],
-    "tests": tests_require,
+    "tests": [
+        "pytest-reana>=0.95.0a2,<0.96.0",
+    ],
 }
 
 extras_require["all"] = []
@@ -74,7 +72,6 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 install_requires = [
     "alembic>=1.4.2",
     "psycopg2-binary>=2.6.1",
@@ -78,7 +74,6 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#237)**
- **build(python): remove deprecated `pytest-runner` (#237)**
- **build(python): use optional deps instead of `tests_require` (#237)**
- **build(python): add minimal `pyproject.toml` (#237)**

Closes https://github.com/reanahub/reana/issues/814