### PR TITLE
feat(models): add job metrics in workflow model

### DIFF
--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -542,6 +542,7 @@ class Workflow(Base, Timestamp, QuotaBase):
     complexity = Column(ARRAY(BigInteger(), dimensions=2), default=[])
     type_ = Column(String(30))
     logs = Column(String)
+    metrics = Column(JSONType)
     run_started_at = Column(DateTime)
     run_finished_at = Column(DateTime)
     run_stopped_at = Column(DateTime)


### PR DESCRIPTION
In order to store job metrics in Reana DB, we need to introduce a field. This is a first attempt.