### PR TITLE
feat: add identity provider ID to User model

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,4 +17,5 @@ The list of contributors in alphabetical order:
 - [Rokas Maciulaitis](https://orcid.org/0000-0003-1064-6967)
 - [Sinclert Perez](https://www.linkedin.com/in/sinclert)
 - [Tibor Simko](https://orcid.org/0000-0001-7202-5803)
+- [Tomas Ondrejka](https://www.linkedin.com/in/tomas-ondrejka/)
 - [Vladyslav Moisieienkov](https://orcid.org/0000-0001-9717-0775)

--- a/reana_db/alembic/versions/20250813_1001_48294850c570_add_idp_data_to_user.py
+++ b/reana_db/alembic/versions/20250813_1001_48294850c570_add_idp_data_to_user.py
@@ -1,0 +1,37 @@
+"""add idp data to user.
+
+Revision ID: 48294850c570
+Revises: 3da4dd5d0b75
+Create Date: 2025-08-13 10:01:02.408799
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "48294850c570"
+down_revision = "3da4dd5d0b75"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade to 48294850c570 revision."""
+    op.add_column(
+        "user_",
+        sa.Column("idp_issuer", sa.String(length=255), nullable=True),
+        schema="__reana",
+    )
+    op.add_column(
+        "user_",
+        sa.Column("idp_subject", sa.String(length=255), nullable=True),
+        schema="__reana",
+    )
+
+
+def downgrade():
+    """Downgrade to 3da4dd5d0b75 revision."""
+    op.drop_column("user_", "idp_subject", schema="__reana")
+    op.drop_column("user_", "idp_issuer", schema="__reana")

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -178,6 +178,8 @@ class User(Base, Timestamp, QuotaBase):
         sync_backref=False,
     )
     audit_logs = relationship("AuditLog", backref="user_")
+    idp_issuer = Column(String(length=255))
+    idp_subject = Column(String(length=255))
 
     def __init__(self, access_token=None, **kwargs):
         """Initialize user model."""


### PR DESCRIPTION
* Add `idp_issuer` and `idp_subject` columns to User model for external identity provider integration
* Support mapping external identity provider subject claims to REANA users
* Enable user lookup by identity provider ID

This change allows storing external identity provider subject identifiers in the database, supporting the JWT authentication feature by creating a mapping between external identity providers and REANA user accounts.

More information on our efforts and progress can be found in [this issue](https://github.com/reanahub/reana-server/issues/743) 