### PR TITLE
ci(python): pin setuptools below 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -156,7 +156,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install twine wheel
           pip install -e .[all]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+setuptools<81
 -e .[all]

--- a/reana_db/alembic/versions/20200928_1015_c912d4f1e1cc_quota_tables.py
+++ b/reana_db/alembic/versions/20200928_1015_c912d4f1e1cc_quota_tables.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "c912d4f1e1cc"
 down_revision = None

--- a/reana_db/alembic/versions/20210507_1240_4801b98f6408_job_started_and_finished_times.py
+++ b/reana_db/alembic/versions/20210507_1240_4801b98f6408_job_started_and_finished_times.py
@@ -9,7 +9,6 @@ Create Date: 2021-05-07 12:40:54.207470
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "4801b98f6408"
 down_revision = "ad93dae04483"

--- a/reana_db/alembic/versions/20210816_0752_6568d7cb6710_storing_full_workflow_workspace.py
+++ b/reana_db/alembic/versions/20210816_0752_6568d7cb6710_storing_full_workflow_workspace.py
@@ -13,7 +13,6 @@ from reana_commons.config import SHARED_VOLUME_PATH
 import sqlalchemy as sa
 import os
 
-
 # revision identifiers, used by Alembic.
 revision = "6568d7cb6710"
 down_revision = "f84e17bd6b18"

--- a/reana_db/alembic/versions/20220307_1247_d34f3905043c_workflow_launcher_url.py
+++ b/reana_db/alembic/versions/20220307_1247_d34f3905043c_workflow_launcher_url.py
@@ -9,7 +9,6 @@ Create Date: 2022-03-07 12:47:11.867026
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "d34f3905043c"
 down_revision = "6568d7cb6710"

--- a/reana_db/alembic/versions/20220711_1301_b92fe567be5b_retention_rules.py
+++ b/reana_db/alembic/versions/20220711_1301_b92fe567be5b_retention_rules.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
 
-
 # revision identifiers, used by Alembic.
 revision = "b92fe567be5b"
 down_revision = "d34f3905043c"

--- a/reana_db/alembic/versions/20221006_1140_377cfbfccf75_retention_rules_pending_status.py
+++ b/reana_db/alembic/versions/20221006_1140_377cfbfccf75_retention_rules_pending_status.py
@@ -9,7 +9,6 @@ Create Date: 2022-10-06 11:40:29.912743
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "377cfbfccf75"
 down_revision = "b92fe567be5b"

--- a/reana_db/alembic/versions/20231002_1208_b85c3e601de4_separate_run_and_restart_number.py
+++ b/reana_db/alembic/versions/20231002_1208_b85c3e601de4_separate_run_and_restart_number.py
@@ -9,7 +9,6 @@ Create Date: 2023-10-02 12:08:18.292490
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "b85c3e601de4"
 down_revision = "377cfbfccf75"
@@ -56,8 +55,7 @@ def upgrade():
     # (thus erroneously having the following run_number_major), in case some of them
     # were created before the limit on 9 restarts was introduced.
     op.get_bind().execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE __reana.workflow AS w
             SET
                 run_number_major = to_be_updated.new_major_run_number,
@@ -69,8 +67,7 @@ def upgrade():
                 GROUP BY w1.workspace_path
             ) AS to_be_updated
             WHERE w.workspace_path = to_be_updated.workspace_path
-            """
-        ),
+            """),
     )
 
 

--- a/reana_db/alembic/versions/20231129_1356_eb5309f3d8ee_improve_indexes_usage.py
+++ b/reana_db/alembic/versions/20231129_1356_eb5309f3d8ee_improve_indexes_usage.py
@@ -8,7 +8,6 @@ Create Date: 2023-11-29 13:56:23.588587
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision = "eb5309f3d8ee"
 down_revision = "2461610e9698"

--- a/reana_db/alembic/versions/20250117_1005_3d0994430da7_add_service_tables.py
+++ b/reana_db/alembic/versions/20250117_1005_3d0994430da7_add_service_tables.py
@@ -10,7 +10,6 @@ import sqlalchemy_utils
 import sqlalchemy as sa
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision = "3d0994430da7"
 down_revision = "2e82f33ee37d"

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -68,7 +68,6 @@ from sqlalchemy_utils.models import Timestamp
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 
-
 convention = {
     "ix": "ix_%(column_0_label)s",
     "uq": "uq_%(table_name)s_%(column_0_name)s",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@
 
 """Pytest configuration for REANA-DB."""
 
-
 from datetime import datetime, timedelta
 from uuid import uuid4
 


### PR DESCRIPTION
Pin setuptools<81 in CI workflows and ReadTheDocs
configuration. This is because the recent setuptools
81.0.0 upgrade removed the pkg_resources module that
is needed at runtime by some dependencies.