### PR TITLE
fix(db): dispose engine connection pool at process exit

### DIFF
--- a/reana_db/database.py
+++ b/reana_db/database.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2020, 2021 CERN.
+# Copyright (C) 2018, 2020, 2021, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +9,8 @@
 """Database management for REANA."""
 
 from __future__ import absolute_import
+
+import atexit
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -36,6 +38,7 @@ engine = create_engine(
 )
 Session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 Base.query = Session.query_property()
+atexit.register(engine.dispose)
 
 
 def init_db():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2025 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-DB database tests."""
+
+import importlib
+
+import mock
+
+
+def test_engine_dispose_registered_at_exit():
+    """Test that engine.dispose is registered to run at process exit.
+
+    This verifies that when any process using reana-db exits (CronJob containers,
+    long-running services), SQLAlchemy sends proper TCP FIN messages to PostgreSQL
+    rather than abandoning connections, which would cause 'unexpected EOF' log noise.
+    """
+    with mock.patch("atexit.register") as mock_register:
+        import reana_db.database as db_module
+
+        importlib.reload(db_module)
+        mock_register.assert_any_call(db_module.engine.dispose)


### PR DESCRIPTION
## What this PR does

Registers `engine.dispose()` as an `atexit` handler in `reana_db/database.py` so that all pooled database connections are cleanly closed — with a proper TCP FIN — before any process using `reana-db` exits.

## Root cause

The module-level `engine` in `database.py` holds a SQLAlchemy connection pool. When a short-lived process exits (e.g. a CronJob container), this pool is garbage-collected without calling `engine.dispose()`. Python's GC does not send PostgreSQL `Terminate` messages, so the server sees an abrupt disconnect and logs:

```
LOG: unexpected EOF on client connection with an open transaction
```

For Flask-based commands this is compounded by `teardown_appcontext` calling only `session.remove()` (which returns connections to the pool) without disposing the pool itself.

## Affected CronJob containers

All four CronJob containers that use `reana-db` are fixed by this single change, since they all share the same module-level `engine`:

| CronJob | Command |
|---|---|
| `reana-system-status` | `flask reana-admin status-report` |
| `reana-retention-rules-apply` | `flask reana-admin retention-rules-apply` |
| `reana-resource-quota-update` | `reana-db quota resource-usage-update` |
| `reana-interactive-session-cleanup` | `flask reana-admin interactive-session-cleanup` |

Note: `reana-interactive-session-cleanup` was not mentioned in the original issue but is affected by the same root cause.

## The fix

```python
atexit.register(engine.dispose)
```

`atexit` is Python's standard library — no new package dependency. The handler fires once when the process is about to exit, regardless of how the process was started (Flask CLI, plain Click CLI, or long-running server). For long-running services, this is equally correct: `engine.dispose()` on graceful shutdown cleanly closes all idle pooled connections.

## Tests

A unit test (`tests/test_database.py`) verifies that `engine.dispose` is registered as an atexit handler by reloading the module with a mocked `atexit.register` and asserting it was called.

### Verifying the fix end-to-end

The unit test confirms the registration, but the most direct proof is observing PostgreSQL's connection logs before and after. To reproduce on any deployment with access to PostgreSQL logs:

**1. Enable connection logging:**
```sql
ALTER SYSTEM SET log_connections = on;
ALTER SYSTEM SET log_disconnections = on;
SELECT pg_reload_conf();
```

**2. Run a CronJob command without the fix:**
```bash
reana-db quota resource-usage-update
```

**3. Check PostgreSQL logs — you'll see:**
```
LOG: unexpected EOF on client connection with an open transaction
```

**4. Apply this fix and run the same command again — you'll see instead:**
```
LOG: disconnection: session time: 0:00:00.012 user=postgres database=postgres ...
```

A clean `disconnection` entry confirms that `engine.dispose()` sent the proper `Terminate` message before the process exited.

Closes reanahub/reana#943