### PR TITLE
build(python): upgrade to SQLAlchemy 2.x

### DIFF
--- a/reana_db/alembic/versions/20240531_0959_86435bb00714_foreign_key_for_workflow_uuid_of_job.py
+++ b/reana_db/alembic/versions/20240531_0959_86435bb00714_foreign_key_for_workflow_uuid_of_job.py
@@ -49,13 +49,13 @@ def upgrade():
     #     1b. delete jobs from `job` table
     op.execute(
         job_table.delete().where(
-            job_table.c.workflow_uuid.notin_(sa.select([workflow_table.c.id_]))
+            job_table.c.workflow_uuid.notin_(sa.select(workflow_table.c.id_))
         )
     )
     #     1c. delete rows in `job_cache` that reference deleted jobs
     op.execute(
         job_cache_table.delete().where(
-            job_cache_table.c.job_id.notin_(sa.select([job_table.c.id_]))
+            job_cache_table.c.job_id.notin_(sa.select(job_table.c.id_))
         )
     )
     #     1d. enable foreign key checks

--- a/reana_db/database.py
+++ b/reana_db/database.py
@@ -34,8 +34,7 @@ engine = create_engine(
     pool_size=SQLALCHEMY_POOL_SIZE,
     pool_timeout=SQLALCHEMY_POOL_TIMEOUT,
 )
-Session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
-Base.query = Session.query_property()
+Session = scoped_session(sessionmaker(autoflush=False, bind=engine))
 
 
 def init_db():
@@ -43,8 +42,11 @@ def init_db():
     import reana_db.models
 
     reana_schema_name = "__reana"
-    if not engine.dialect.has_schema(engine, reana_schema_name):
-        event.listen(Base.metadata, "before_create", CreateSchema(reana_schema_name))
+    with engine.connect() as connection:
+        if not engine.dialect.has_schema(connection, reana_schema_name):
+            event.listen(
+                Base.metadata, "before_create", CreateSchema(reana_schema_name)
+            )
     if not database_exists(engine.url):
         create_database(engine.url)
     Base.metadata.create_all(bind=engine)

--- a/reana_db/models.py
+++ b/reana_db/models.py
@@ -60,7 +60,7 @@ from sqlalchemy import (
     or_,
     text,
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy_utils import EncryptedType, JSONType, UUIDType
@@ -282,7 +282,9 @@ class User(Base, Timestamp, QuotaBase):
 
     def initialize_user_quota_limits(self):
         """Initialize user quota limits."""
-        resources = Resource.query.all()
+        from .database import Session
+
+        resources = Session.query(Resource).all()
         for resource in resources:
             self.resources.append(
                 UserResource(
@@ -770,7 +772,9 @@ class Workflow(Base, Timestamp, QuotaBase):
 
     def activate_workspace_retention_rules(self):
         """Activate workspace retention rules for the workflow."""
-        rules = WorkspaceRetentionRule.query.filter_by(
+        from .database import Session
+
+        rules = Session.query(WorkspaceRetentionRule).filter_by(
             workflow_id=self.id_, status=WorkspaceRetentionRuleStatus.created
         )
         update_workspace_retention_rules(rules, WorkspaceRetentionRuleStatus.active)
@@ -782,7 +786,9 @@ class Workflow(Base, Timestamp, QuotaBase):
         the same name and the same major run number. This includes the
         original workflow, as well as all the following restarts.
         """
-        restarts = Workflow.query.filter(
+        from .database import Session
+
+        restarts = Session.query(Workflow).filter(
             Workflow.name == self.name,
             Workflow.owner_id == self.owner_id,
             Workflow.run_number_major == self.run_number_major,
@@ -791,13 +797,19 @@ class Workflow(Base, Timestamp, QuotaBase):
 
     def inactivate_workspace_retention_rules(self):
         """Inactivate workspace retention rules for all the parent workflows."""
-        rules = WorkspaceRetentionRule.query.join(
-            self.get_all_restarts().subquery()
-        ).filter(
-            or_(
-                WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.created,
-                WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.active,
-            ),
+        from .database import Session
+
+        rules = (
+            Session.query(WorkspaceRetentionRule)
+            .join(self.get_all_restarts().subquery())
+            .filter(
+                or_(
+                    WorkspaceRetentionRule.status
+                    == WorkspaceRetentionRuleStatus.created,
+                    WorkspaceRetentionRule.status
+                    == WorkspaceRetentionRuleStatus.active,
+                ),
+            )
         )
         update_workspace_retention_rules(rules, WorkspaceRetentionRuleStatus.inactive)
 
@@ -807,10 +819,14 @@ class Workflow(Base, Timestamp, QuotaBase):
         All the restarts of the workflow are considered when checking the retention
         rules, as they all share the same workspace.
         """
-        pending_rules = WorkspaceRetentionRule.query.join(
-            self.get_all_restarts().subquery()
-        ).filter(
-            WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.pending,
+        from .database import Session
+
+        pending_rules = (
+            Session.query(WorkspaceRetentionRule)
+            .join(self.get_all_restarts().subquery())
+            .filter(
+                WorkspaceRetentionRule.status == WorkspaceRetentionRuleStatus.pending,
+            )
         )
         return pending_rules.first() is not None
 
@@ -1118,9 +1134,10 @@ class WorkspaceRetentionRule(Base):
 def workspace_retention_change_listener(mapper, connection, workspace_retention_rule):
     """Workspace retention change listener."""
     connection.execute(
-        WorkspaceRetentionAuditLog.__table__.insert(),
-        workspace_retention_rule_id=workspace_retention_rule.id_,
-        action=workspace_retention_rule.status,
+        WorkspaceRetentionAuditLog.__table__.insert().values(
+            workspace_retention_rule_id=workspace_retention_rule.id_,
+            action=workspace_retention_rule.status,
+        )
     )
 
 
@@ -1207,7 +1224,7 @@ class Resource(Base, Timestamp):
         """Initialise default Resources."""
         from reana_db.database import Session
 
-        existing_resources = [r.name for r in Resource.query.all()]
+        existing_resources = [r.name for r in Session.query(Resource).all()]
         default_resources = []
         resource_type_to_unit = {
             ResourceType.cpu: ResourceUnit.milliseconds,

--- a/reana_db/utils.py
+++ b/reana_db/utils.py
@@ -79,6 +79,7 @@ def _get_workflow_with_uuid_or_name(
 
     :rtype: reana-db.models.Workflow
     """
+    from reana_db.database import Session
     from reana_db.models import UserWorkflow, Workflow
 
     # Check existence
@@ -156,9 +157,8 @@ def _get_workflow_with_uuid_or_name(
         # Search by `run_number_major` and `run_number_minor`, since it is a primary key.
         if include_shared_workflows:
             workflow = (
-                Workflow.query.outerjoin(
-                    UserWorkflow, UserWorkflow.workflow_id == Workflow.id_
-                )
+                Session.query(Workflow)
+                .outerjoin(UserWorkflow, UserWorkflow.workflow_id == Workflow.id_)
                 .filter(
                     (Workflow.name == workflow_name)
                     & (Workflow.run_number_major == run_number_major)
@@ -171,12 +171,16 @@ def _get_workflow_with_uuid_or_name(
                 .one_or_none()
             )
         else:
-            workflow = Workflow.query.filter(
-                Workflow.name == workflow_name,
-                Workflow.run_number_major == run_number_major,
-                Workflow.run_number_minor == run_number_minor,
-                Workflow.owner_id == user_uuid,
-            ).one_or_none()
+            workflow = (
+                Session.query(Workflow)
+                .filter(
+                    Workflow.name == workflow_name,
+                    Workflow.run_number_major == run_number_major,
+                    Workflow.run_number_minor == run_number_minor,
+                    Workflow.owner_id == user_uuid,
+                )
+                .one_or_none()
+            )
 
         if not workflow:
             raise ValueError(
@@ -196,13 +200,13 @@ def _get_workflow_by_name(workflow_name, user_uuid, include_shared_workflows=Fal
 
     :rtype: reana-db.models.Workflow
     """
+    from reana_db.database import Session
     from reana_db.models import UserWorkflow, Workflow
 
     if include_shared_workflows:
         workflow = (
-            Workflow.query.outerjoin(
-                UserWorkflow, Workflow.id_ == UserWorkflow.workflow_id
-            )
+            Session.query(Workflow)
+            .outerjoin(UserWorkflow, Workflow.id_ == UserWorkflow.workflow_id)
             .filter(
                 (Workflow.name == workflow_name)
                 & (
@@ -217,9 +221,8 @@ def _get_workflow_by_name(workflow_name, user_uuid, include_shared_workflows=Fal
         )
     else:
         workflow = (
-            Workflow.query.filter(
-                Workflow.name == workflow_name, Workflow.owner_id == user_uuid
-            )
+            Session.query(Workflow)
+            .filter(Workflow.name == workflow_name, Workflow.owner_id == user_uuid)
             .order_by(
                 Workflow.run_number_major.desc(), Workflow.run_number_minor.desc()
             )
@@ -245,13 +248,13 @@ def _get_workflow_by_uuid(workflow_uuid, user_uuid, include_shared_workflows=Fal
 
     :rtype: reana-db.models.Workflow
     """
+    from reana_db.database import Session
     from reana_db.models import UserWorkflow, Workflow
 
     if include_shared_workflows:
         workflow = (
-            Workflow.query.outerjoin(
-                UserWorkflow, Workflow.id_ == UserWorkflow.workflow_id
-            )
+            Session.query(Workflow)
+            .outerjoin(UserWorkflow, Workflow.id_ == UserWorkflow.workflow_id)
             .filter(
                 (Workflow.id_ == workflow_uuid)
                 & (
@@ -262,9 +265,11 @@ def _get_workflow_by_uuid(workflow_uuid, user_uuid, include_shared_workflows=Fal
             .first()
         )
     else:
-        workflow = Workflow.query.filter(
-            Workflow.id_ == workflow_uuid, Workflow.owner_id == user_uuid
-        ).first()
+        workflow = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == workflow_uuid, Workflow.owner_id == user_uuid)
+            .first()
+        )
 
     if not workflow:
         raise ValueError(
@@ -350,7 +355,13 @@ def get_default_quota_resource(resource_type):
             "Default resource of type {} does not exist.".format(resource_type)
         )
 
-    return Resource.query.filter_by(name=DEFAULT_QUOTA_RESOURCES[resource_type]).one()
+    from reana_db.database import Session
+
+    return (
+        Session.query(Resource)
+        .filter_by(name=DEFAULT_QUOTA_RESOURCES[resource_type])
+        .one()
+    )
 
 
 def should_skip_quota_update(resource_type) -> bool:
@@ -397,12 +408,14 @@ def update_users_disk_quota(
 
     disk_resource = get_default_quota_resource(ResourceType.disk.name)
 
-    users = [user] if user else User.query.all()
+    users = [user] if user else Session.query(User).all()
     timer = Timer("User disk quota usage update", total=len(users))
     for u in users:
-        user_resource_quota = UserResource.query.filter_by(
-            user_id=u.id_, resource_id=disk_resource.id_
-        ).one()
+        user_resource_quota = (
+            Session.query(UserResource)
+            .filter_by(user_id=u.id_, resource_id=disk_resource.id_)
+            .one()
+        )
         if bytes_to_sum is not None:
             updated_quota_usage = user_resource_quota.quota_used + bytes_to_sum
             if updated_quota_usage < 0:
@@ -423,7 +436,7 @@ def update_users_disk_quota(
                 )
                 .filter(WorkflowResource.workflow_id == Workflow.id_)
                 .filter(WorkflowResource.resource_id == disk_resource.id_)
-                .filter(Workflow.id_.in_(Session.query(u.workflows.subquery().c.id_)))
+                .filter(Workflow.owner_id == u.id_)
                 # multiple workflows might have the same workspace path, so the query groups
                 # by `workspace_path` in order to consider each workspace only once
                 .group_by(Workflow.workspace_path)
@@ -459,9 +472,11 @@ def update_workflow_cpu_quota(workflow) -> int:
         # WorkflowResource might exist already if the cluster
         # follows a combined termination + periodic policy (eg. created
         # by the status listener, revisited by the cronjob)
-        workflow_resource = WorkflowResource.query.filter_by(
-            workflow_id=workflow.id_, resource_id=cpu_resource.id_
-        ).one_or_none()
+        workflow_resource = (
+            Session.query(WorkflowResource)
+            .filter_by(workflow_id=workflow.id_, resource_id=cpu_resource.id_)
+            .one_or_none()
+        )
         if workflow_resource:
             workflow_resource.quota_used = cpu_milliseconds
         else:
@@ -483,9 +498,11 @@ def update_workflows_cpu_quota() -> None:
 
     # logs and reana_specification are not loaded to avoid consuming
     # huge amounts of memory
-    workflows = Workflow.query.options(
-        defer(Workflow.logs), defer(Workflow.reana_specification)
-    ).all()
+    workflows = (
+        Session.query(Workflow)
+        .options(defer(Workflow.logs), defer(Workflow.reana_specification))
+        .all()
+    )
     # We expunge all the workflows, as they will not be modified when updating the quotas.
     # This makes `Session.commit()` much faster
     for workflow in workflows:
@@ -512,6 +529,7 @@ def update_users_cpu_quota(user=None) -> None:
         UserResource,
         UserToken,
         UserTokenStatus,
+        Workflow,
         WorkflowResource,
     )
 
@@ -524,7 +542,8 @@ def update_users_cpu_quota(user=None) -> None:
         users = [user]
     else:
         users = (
-            User.query.join(UserToken)
+            Session.query(User)
+            .join(UserToken)
             .filter_by(status=UserTokenStatus.active)  # skip users with no active token
             .all()
         )
@@ -533,14 +552,17 @@ def update_users_cpu_quota(user=None) -> None:
         cpu_milliseconds = (
             Session.query(func.sum(WorkflowResource.quota_used))
             .filter(WorkflowResource.resource_id == cpu_resource.id_)
-            .join(user.workflows.subquery())
+            .join(Workflow, WorkflowResource.workflow_id == Workflow.id_)
+            .filter(Workflow.owner_id == user.id_)
             .scalar()
         )
         if not cpu_milliseconds:
             cpu_milliseconds = 0
-        user_resource_quota = UserResource.query.filter_by(
-            user_id=user.id_, resource_id=cpu_resource.id_
-        ).first()
+        user_resource_quota = (
+            Session.query(UserResource)
+            .filter_by(user_id=user.id_, resource_id=cpu_resource.id_)
+            .first()
+        )
         user_resource_quota.quota_used = cpu_milliseconds
         Session.commit()
         timer_user.count_event()
@@ -659,9 +681,11 @@ def update_workflows_disk_quota() -> None:
 
     # logs and reana_specification are not loaded to avoid consuming
     # huge amounts of memory
-    workflows = Workflow.query.options(
-        defer(Workflow.logs), defer(Workflow.reana_specification)
-    ).all()
+    workflows = (
+        Session.query(Workflow)
+        .options(defer(Workflow.logs), defer(Workflow.reana_specification))
+        .all()
+    )
     # We expunge all the workflows, as they will not be modified when updating the quotas.
     # This makes `Session.commit()` much faster
     for workflow in workflows:
@@ -696,7 +720,7 @@ def change_key_encrypted_columns(old_key):
 
     # write columns to the database to encrypt them with new key
     for user_token in user_tokens:
-        UserToken.query.filter_by(id_=user_token.id_).update(
+        Session.query(UserToken).filter_by(id_=user_token.id_).update(
             {"token": user_token.token}
         )
     Session.commit()

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ for key, reqs in extras_require.items():
 install_requires = [
     "alembic>=1.4.2",
     "psycopg2-binary>=2.6.1",
-    "SQLAlchemy>=1.2.7,<1.5.0",
-    "SQLAlchemy-Utils[encrypted]>=0.37.0",
+    "SQLAlchemy>=2.0.0,<3.0.0",
+    "SQLAlchemy-Utils[encrypted]>=0.41.0,<0.42.0",
     "reana-commons>=0.95.0a1,<0.96.0",
 ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -295,9 +295,8 @@ def test_workflow_cpu_quota_usage_update(db, session, run_workflow):
     workflow = run_workflow(time_elapsed_seconds=time_elapsed_seconds)
     cpu_resource = get_default_quota_resource(ResourceType.cpu.name)
     cpu_milliseconds = (
-        WorkflowResource.query.filter_by(
-            workflow_id=workflow.id_, resource_id=cpu_resource.id_
-        )
+        session.query(WorkflowResource)
+        .filter_by(workflow_id=workflow.id_, resource_id=cpu_resource.id_)
         .first()
         .quota_used
     )


### PR DESCRIPTION
Upgrade SQLAlchemy from `<1.5.0` to `>=2.0.0` and SQLAlchemy-Utils to `>=0.41.0,<0.42.0` to support the latest Invenio packages and to unblock Snakemake `>=9.17.0` which depends on sqlmodel (requires SQLAlchemy 2.x).

Adapt the database session factory to the new API by removing the `autocommit` parameter from `sessionmaker()` (which is gone in 2.x) and removing `Base.query = Session.query_property()` (since the `Model.query` shortcut is no longer supported). Replace all `Model.query` call sites in models and utility code with explicit `Session.query(Model)` queries.

Adjust the connection-based code paths to the SQLAlchemy 2.x API. The `init_db()` schema check is now wrapped in `engine.connect()` since `dialect.has_schema()` requires a connection rather than an engine. The workspace retention event listener uses `.values()` when executing inserts, since keyword-style execution is no longer supported.

Fix the `declarative_base` import path, which moved from `sqlalchemy.ext.declarative` to `sqlalchemy.orm`. Update one Alembic migration to use the keyword-style `sa.select(column)` syntax instead of the deprecated list-based `sa.select([column])`.

Closes reanahub/reana-server#770.