### PR TITLE
ci(run-tests): improve old DB container cleanup

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -32,7 +32,7 @@ clean_old_db_container() {
     OLD="$(docker ps --all --quiet --filter=name=postgres__reana-db)"
     if [ -n "$OLD" ]; then
         echo '==> [INFO] Cleaning old DB container...'
-        docker stop postgres__reana-db
+        docker rm -f postgres__reana-db >/dev/null 2>&1 || true
     fi
 }
 


### PR DESCRIPTION
Replace `docker stop` with `docker rm -f` when cleaning the old Postgres test container. Stopping a `--rm` container triggers asynchronous removal, so on faster machines the next `docker run --rm` could fire before the old container was gone, leading to a name conflict. `docker rm -f` stops and removes synchronously, so the subsequent `docker run` always succeeds.